### PR TITLE
Bugfix: error when drift adapter is None

### DIFF
--- a/src/framework/adapters/base.py
+++ b/src/framework/adapters/base.py
@@ -48,6 +48,10 @@ class DriftModelAdapterBase(Generic[MODEL], ModelAdapterBase[MODEL]):
         if drift_adapter is None:
             print("WARNING: Drift-detecting model's adapter initialized without specifying drift_adapter. The drift detector's state will not be logged.")
 
+        if not isinstance(drift_adapter, type):
+            print("WARNING: The drift detector adapter is expected to be a type, not an instance.")
+            drift_adapter = drift_adapter.__class__
+
         self._drift_adapter = drift_adapter
         self._drift_adapters: dict[str, ModelAdapterBase] = dict()
     


### PR DESCRIPTION
Should fix the error encountered by @desecnd 

![image](https://github.com/rswc/ml-ids/assets/48861946/8cb096c1-6eec-4d94-9cec-29a20acd45d0)

So now, if you want to run an experiment without an adapter for the drift detector (maybe it's not implemented or you don't care about the state of the detector, you need the model adapter only), you can.