### PR TITLE
Bugfix lack of seed in CBCE tests

### DIFF
--- a/tests/test_cbce.py
+++ b/tests/test_cbce.py
@@ -9,7 +9,7 @@ class TestCBCE:
         """
         Model based on Logistic Regression should be able to learn a basic binary problem.
         """
-        model = CBCE(linear_model.LogisticRegression())
+        model = CBCE(linear_model.LogisticRegression(), seed=42)
         
         DATA = [
             ({"x": 1}, "pos"),
@@ -31,7 +31,7 @@ class TestCBCE:
         Receiving the first sample of a novel class should have no impact on the predictions.
         """
 
-        model = CBCE(linear_model.LogisticRegression())
+        model = CBCE(linear_model.LogisticRegression(), seed=42)
 
         DATA = [
             ({"x": 1}, "majority"),
@@ -59,7 +59,7 @@ class TestCBCE:
         once new samples belonging to them arrive.
         """
 
-        model = CBCE(linear_model.LogisticRegression(), disappearance_threshold=0.9**100)
+        model = CBCE(linear_model.LogisticRegression(), disappearance_threshold=0.9**100, seed=42)
 
         DATA = [
             ({"x": 1}, "A"),
@@ -101,7 +101,7 @@ class TestCBCE:
         """
         random.seed(42)
 
-        model = CBCE(linear_model.LogisticRegression(), drift_detector=DDM())
+        model = CBCE(linear_model.LogisticRegression(), drift_detector=DDM(), seed=42)
 
         VALUE_BASE = [2, -2]
         LABEL = ["A", "B"]
@@ -131,7 +131,7 @@ class TestCBCE:
         """
         random.seed(42)
 
-        model = CBCE(linear_model.LogisticRegression(), drift_detector=DDM())
+        model = CBCE(linear_model.LogisticRegression(), drift_detector=DDM(), seed=42)
 
         VALUE_BASE = [10, -10]
         LABEL = ["A", "B"]


### PR DESCRIPTION
I found that CBCE model in pytest section is initialized without seed. 

I believe UnitTests related to probabilistic drift detection should be initalized without random element, otherwise if we want to make sure it works in "x%", we can run it with different seeds  / repeated runs and expect result to be "passed" some fraction of x times. 

Correct me if I got something wrong, and probably we will see if it passes in the current workflow 👀 