### PR TITLE
Add option to set summary metric

### DIFF
--- a/src/framework/runner.py
+++ b/src/framework/runner.py
@@ -23,16 +23,18 @@ class BaseRunner:
             metrics: Metrics,
             out_dir: str,
             model_adapter: ModelAdapterBase = None,
+            summary_metric: str = "mean",
             enable_tracker: bool = True,
             project: str = None,
             entity: str = None,
             notes: str = None,
-            tags: list[str] = None
+            tags: list[str] = None,
         ) -> None:
         self.model = model
         self.dataset = dataset
         self.metrics = metrics
         self.out_dir = out_dir
+        self.sumary_metric = summary_metric
         self.entity = entity
         self.project = project
         self.notes = notes
@@ -98,6 +100,7 @@ class ExperimentRunner(BaseRunner):
             out_dir: str,
             name: str = None,
             model_adapter: ModelAdapterBase = None,
+            summary_metric: str = "mean",
             enable_tracker: bool = True,
             project: str = None,
             entity: str = None,
@@ -110,6 +113,7 @@ class ExperimentRunner(BaseRunner):
             metrics=metrics,
             out_dir=out_dir,
             model_adapter=model_adapter,
+            summary_metric=summary_metric,
             enable_tracker=enable_tracker,
             project=project,
             entity=entity,
@@ -133,7 +137,8 @@ class ExperimentRunner(BaseRunner):
             "hyperparameters": self.model._get_params(),
             "dataset": self.dataset._repr_content,
             "metrics": self._metrics_names,
-            "adapter": self.model_adapter.get_parameters() if self.model_adapter else None
+            "adapter": self.model_adapter.get_parameters() if self.model_adapter else None,
+            "summary_metrics": self.sumary_metric,
         }
     
     def run(self):
@@ -153,6 +158,9 @@ class ExperimentRunner(BaseRunner):
 
         print("Metadata available at:", os.path.abspath(self._meta_path))
         print("Metrics log available at:", os.path.abspath(self._metrics_path))
+
+        for metric in self.metrics:
+            wandb.define_metric(extract_metric_name(metric), summary=self.sumary_metric)
 
         with open(self._metrics_path, "x", newline="") as file_metrics:
             writer_metrics = csv.writer(file_metrics)


### PR DESCRIPTION
This PR adds an option (`summary_metric`) to `ExperimentRunner`, which can be used to configure how the summary metrics are calculated. By default, it's `mean`. This is based on an [existing w&b feature](https://docs.wandb.ai/guides/track/log/log-summary), which has somewhat limited options, but I don't think anything fancier (like using `river.stats`) is needed at the moment.

![image](https://github.com/rswc/ml-ids/assets/48861946/c46ce167-cece-49b2-8d6e-cae2ee4997b3)
![image](https://github.com/rswc/ml-ids/assets/48861946/3fff246d-0ddb-4890-a12c-f6a89018e7ce)

Closes #61 